### PR TITLE
Increase font-size for code; adjust background-color for dfn > code

### DIFF
--- a/base.css
+++ b/base.css
@@ -59,7 +59,6 @@ a {
 code {
   background-color: #eee;
   font-family: 'Droid Sans Mono', monospace;
-  font-size: 0.8em;
 }
 
 body > pre.prettyprint,
@@ -147,6 +146,10 @@ dfn {
   background-color: #f9f9f9;
   padding: 0 2px;
   outline: 1px solid #eee;
+}
+
+dfn > code {
+  background-color: transparent;
 }
 
 dfn.no-references {


### PR DESCRIPTION
IMO, the readability for code elements gets better with this change, and I added the `background-color: transparent;` for dfn > code elements to get them displayed in a single color tone.
