### PR TITLE
Make <pre> inherit the class from <spec-idl>

### DIFF
--- a/code.html
+++ b/code.html
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<polymer-element name="spec-code" noscript>
+<polymer-element name="spec-code" attributes="class" noscript>
   <template>
     <style>
       :host { display: block }
@@ -34,6 +34,6 @@ limitations under the License.
       }
 
     </style>
-<pre><code><content></content></code></pre>
+<pre class="{{class}}"><code><content></content></code></pre>
   </template>
 </polymer-element>


### PR DESCRIPTION
That way, the generated code has `<pre class=idl>`, which allows to identify and extract IDL fragments automatically from the spec. Most other specs follow that markup convention.
